### PR TITLE
Handle invalid JSON payload in MQTT bridge

### DIFF
--- a/mqttbridge.py
+++ b/mqttbridge.py
@@ -7,6 +7,9 @@ app = Flask(__name__)
 def send():
     try:
         data = request.get_json()
+        if data is None:
+            return jsonify({"error": "Invalid JSON payload"}), 400
+
         topic = data.get("topic")
         message = data.get("message")
 

--- a/tests/test_mqttbridge.py
+++ b/tests/test_mqttbridge.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import mqttbridge
+import pytest
+
+@pytest.fixture
+def client():
+    mqttbridge.app.config['TESTING'] = True
+    with mqttbridge.app.test_client() as client:
+        yield client
+
+def test_send_valid_payload(mocker, client):
+    mock_publish = mocker.patch('mqttbridge.publish.single')
+    resp = client.post('/send', json={'topic': 'test', 'message': 'hello'})
+    assert resp.status_code == 200
+    assert resp.get_json() == {'status': 'Message published'}
+    mock_publish.assert_called_once_with('test', 'hello', hostname='localhost')
+
+def test_send_missing_fields(client):
+    resp = client.post('/send', json={'topic': 'test'})
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'Missing topic or message'}
+
+def test_send_invalid_json(client):
+    resp = client.post('/send', data='not json', content_type='text/plain')
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'Invalid JSON payload'}


### PR DESCRIPTION
## Summary
- validate JSON payload in `mqttbridge.py`
- add unit tests for successful, missing field, and invalid JSON cases

## Testing
- `pip install flask` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845769c76f0832a8c6a3a3acfadf591