### PR TITLE
Clarify network interface comment

### DIFF
--- a/mqttbridge.py
+++ b/mqttbridge.py
@@ -20,5 +20,6 @@ def send():
         return jsonify({"error": str(e)}), 500
 
 if __name__ == "__main__":
-    # Make server accessible on your Pi's local IP
+    # Using host="0.0.0.0" exposes the service on all network interfaces,
+    # not only the Pi's specific IP address
     app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- update the comment above `app.run` to explain that using `host="0.0.0.0"` exposes the service on every network interface

## Testing
- `python -m py_compile mqttbridge.py`

------
https://chatgpt.com/codex/tasks/task_e_6845783afa04832abd24b1566b169cc3