### PR TITLE
Specify Info.plist for Swift app

### DIFF
--- a/simpsonsHouse/simpsonsHouse.swiftpm/Package.swift
+++ b/simpsonsHouse/simpsonsHouse.swiftpm/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
             bundleVersion: "1",
             appIcon: .placeholder(icon: .bicycle),
             accentColor: .presetColor(.brown),
+            infoPlist: .file(path: "../Info.plist"),
             supportedDeviceFamilies: [
                 .pad,
                 .phone


### PR DESCRIPTION
## Summary
- reference custom Info.plist file in the Package.swift manifest to avoid it being treated as a resource

## Testing
- `python -m py_compile mqttbridge.py mqttlistener.py`
- `swift package dump-package` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_e_684786bca96c832aa80f17c20367c06b