### PR TITLE
Inject ATS settings via Package manifest

### DIFF
--- a/simpsonsHouse/simpsonsHouse.swiftpm/Package.swift
+++ b/simpsonsHouse/simpsonsHouse.swiftpm/Package.swift
@@ -20,6 +20,9 @@ let package = Package(
             bundleVersion: "1",
             appIcon: .placeholder(icon: .bicycle),
             accentColor: .presetColor(.brown),
+            infoPlist: .extendingDefault(with: [
+                "NSAppTransportSecurity": ["NSAllowsArbitraryLoads": true]
+            ]),
             supportedDeviceFamilies: [
                 .pad,
                 .phone


### PR DESCRIPTION
## Summary
- revert unsupported Info.plist path
- add ATS settings directly in the manifest

## Testing
- `python -m py_compile mqttbridge.py mqttlistener.py`
- `swift package dump-package` *(fails: no such module 'AppleProductTypes')*


------
https://chatgpt.com/codex/tasks/task_e_684786bca96c832aa80f17c20367c06b