### PR TITLE
Update README with Bonjour instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,39 @@ This project provides a simple SwiftUI interface for toggling devices in a simul
 
 `Info.plist` includes the `NSAllowsArbitraryLoads` setting, which disables App Transport Security restrictions so the app can communicate with the local HTTP bridge.
 
+## Advertising the HTTP service via Bonjour
+
+Swift Playgrounds only allows network access to hosts it discovers through Bonjour with service types that match your package's capabilities. To keep the `Info.plist` simple, you can run an mDNS advertiser on the Raspberry Pi so Playgrounds detects the bridge automatically.
+
+1. **Install Avahi**
+   ```bash
+   sudo apt-get update
+   sudo apt-get install avahi-daemon avahi-utils
+   ```
+2. **Create a service definition** at `/etc/avahi/services/mqtt-http.service`:
+   ```xml
+   <?xml version="1.0" standalone='no'?>
+   <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+   <service-group>
+     <name replace-wildcards="yes">Simpsons House MQTT</name>
+     <service>
+       <type>_http._tcp</type>
+       <port>5000</port>
+     </service>
+   </service-group>
+   ```
+3. **Restart Avahi**
+   ```bash
+   sudo systemctl restart avahi-daemon
+   ```
+4. **Verify the broadcast** from a macOS terminal:
+   ```bash
+   dns-sd -B _http._tcp
+   ```
+   The `Simpsons House MQTT` service should appear in the list.
+
+In Playgrounds, enable Local Network under **Settings → Capabilities**, add `_http._tcp` to the Bonjour section, and resume the live view. When prompted, allow the connection. Playgrounds will now discover the Pi's HTTP service and permit calls to `http://10.20.5.66:5000/send`.
+
 ## Opening on an iPad
 
 If you have never used GitHub or Swift Playgrounds before, follow these steps:


### PR DESCRIPTION
## Summary
- document how to advertise the HTTP service via Bonjour using Avahi so Swift Playgrounds can access the Pi

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a7b5e4688832a9f83652b4edc246c