### PR TITLE
Fix README instructions for running listener in venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This project provides a simple SwiftUI interface for toggling devices in a simul
 5. **Open another SSH tab** (Shelly lets you create multiple sessions) and run
    the listener:
    ```bash
-   sudo python mqttlistener.py
+   sudo ./mqttenv/bin/python mqttlistener.py
    ```
 6. **Build and run the Swift package** on your iOS device or simulator.
 


### PR DESCRIPTION
## Summary
- adjust the README to launch `mqttlistener.py` using the Python binary from the virtual environment

## Testing
- `python -m py_compile mqttbridge.py mqttlistener.py`

------
https://chatgpt.com/codex/tasks/task_e_6850cb370804832ab1a16f13f81f46a3