### PR TITLE
Streamline setup with script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,33 +32,15 @@ This project provides a simple SwiftUI interface for toggling devices in a simul
    personal access token or SSH key. You can also download a ZIP file instead,
    as described in the **Opening on an iPad** section.
 
-3. **Set up a Python virtual environment** on the Pi and install the dependencies:
+3. **Run the setup script** to install dependencies and launch the Python services:
    ```bash
-   sudo apt install python3-venv -y
-   python3 -m venv mqttenv
-   source mqttenv/bin/activate
-   pip install flask paho-mqtt RPi.GPIO
+   ./setup.sh
    ```
-   Reactivate the environment with `source mqttenv/bin/activate` whenever you open a new shell before running the scripts.
+   The script installs required packages, sets up a Python virtual environment,
+   starts the Mosquitto broker, and runs both the bridge and listener in the
+   background.
 
-4. **Install and start the Mosquitto MQTT broker** so the bridge and listener can connect:
-   ```bash
-   sudo apt install -y mosquitto
-   sudo systemctl enable mosquitto
-   sudo systemctl start mosquitto
-   ```
-
-5. **Run the MQTT bridge**:
-   ```bash
-   python mqttbridge.py
-   ```
-6. **Open another SSH tab** (Shelly lets you create multiple sessions). In the
-   new shell, navigate back to the project directory and run the listener:
-   ```bash
-   cd simpsons-house
-   sudo ./mqttenv/bin/python mqttlistener.py
-   ```
-7. **Build and run the Swift package** on your iOS device or simulator.
+4. **Build and run the Swift package** on your iOS device or simulator.
 
 ## Allowing HTTP Requests on iOS
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# Install required packages
+sudo apt update
+sudo apt install -y git python3-venv mosquitto
+
+# Clone the repo if needed
+if [ ! -f mqttbridge.py ]; then
+    git clone https://github.com/roanvtkc/simpsons-house.git
+    cd simpsons-house
+fi
+
+# Create the Python virtual environment
+if [ ! -d mqttenv ]; then
+    python3 -m venv mqttenv
+fi
+source mqttenv/bin/activate
+pip install --upgrade pip
+pip install flask paho-mqtt RPi.GPIO
+
+# Enable and start the MQTT broker
+sudo systemctl enable mosquitto
+sudo systemctl start mosquitto
+
+# Launch bridge and listener in the background
+nohup python mqttbridge.py &>/tmp/mqttbridge.log &
+nohup sudo ./mqttenv/bin/python mqttlistener.py &>/tmp/mqttlistener.log &
+
+echo "Setup complete. Bridge and listener are running."


### PR DESCRIPTION
## Summary
- add `setup.sh` to automate installing packages and running services
- simplify README setup instructions to use the new script

## Testing
- `python -m py_compile mqttbridge.py mqttlistener.py`
- `shellcheck setup.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d5b58fac832aaf0bba83139456bb