### PR TITLE
Add CA install script and doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This project provides a simple SwiftUI interface for toggling devices in a simul
      `tkcraspberry`.
 
 2. **Install the TKC Wireless CA certificate** (if required). Some Wi‑Fi setups
-  need this certificate before packages can be downloaded:
+  need this certificate before packages can be downloaded. A helper script
+  (`install_ca.sh`) is included, or you can run the following commands manually:
 
    ```bash
    # Download the PEM into the system CA folder
@@ -35,6 +36,11 @@ This project provides a simple SwiftUI interface for toggling devices in a simul
    grep -R "wirelesstkc" /etc/ssl/certs/ca-certificates.crt && \
      echo "CA installed successfully"
    ```
+
+   You may see an error like `server certificate verification failed. CAfile:
+   none CRLfile: none` when running `apt` or `git`. If so, run the included
+   `install_ca.sh` script (or the commands above) to install the certificate
+   automatically.
 
 3. **Download this repository onto the Pi** so the bridge and listener scripts
    are available. If Git is not installed, you can install it first. The
@@ -54,7 +60,8 @@ This project provides a simple SwiftUI interface for toggling devices in a simul
    ```
    The script installs required packages, sets up a Python virtual environment,
    starts the Mosquitto broker, and runs both the bridge and listener in the
-   background.
+   background. It also calls `install_ca.sh` so the CA certificate is installed
+   automatically if needed.
 
 5. **Build and run the Swift package** on your iOS device or simulator.
 

--- a/install_ca.sh
+++ b/install_ca.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Install the TKC Wireless CA certificate used on some TKC networks.
+# This resolves HTTPS errors like "server certificate verification failed" when
+# running apt or git.
+set -e
+
+CERT_PATH="/usr/local/share/ca-certificates/wirelesstkc.crt"
+
+if [ ! -f "$CERT_PATH" ]; then
+    echo "Downloading TKC Wireless CA certificate..."
+    sudo wget http://10.20.1.206/updates/wirelesstkc.pem -O "$CERT_PATH"
+    echo "Updating CA trust store..."
+    sudo update-ca-certificates
+fi
+
+grep -R "wirelesstkc" /etc/ssl/certs/ca-certificates.crt && \
+    echo "CA installed successfully"

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+# Ensure the TKC Wireless CA certificate is installed so HTTPS downloads work
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/install_ca.sh"
+
 # Install required packages
 sudo apt update
 sudo apt install -y git python3-venv mosquitto


### PR DESCRIPTION
## Summary
- add `install_ca.sh` for automatic TKC CA setup
- call installer from `setup.sh`
- explain CA requirement and new script in the README

## Testing
- `bash -n setup.sh install_ca.sh`

------
https://chatgpt.com/codex/tasks/task_e_685115cdb818832ab8c5868c329d339e